### PR TITLE
doc: add compile guide for ./examples/go

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ NativeTgCalls offers Py Bindings, enabling seamless integration with Python. Fol
 NativeTgCalls offers Go Bindings, enabling seamless integration with Go. Follow these steps to compile NativeTgCalls with Go Bindings:
 1. There is an example project for go in the `./examples/go/` directory, ensure you are in that directory
 2. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
-  2.1 Static won't work
+2.1 Static won't work
 3. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
 4. The rest of the files should be copied to `./examples/go/` directory
-  4.1 `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
+4.1 `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
 5. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
-  5.1 `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
-  5.2 `CGO_ENABLED=1 go run .` for UNIX
+5.1 `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
+5.2 `CGO_ENABLED=1 go run .` for UNIX
 
 
 ### C Bindings

--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ NativeTgCalls offers Py Bindings, enabling seamless integration with Python. Fol
    ```
 ### Go Bindings
 NativeTgCalls offers Go Bindings, enabling seamless integration with Go. Follow these steps to compile NativeTgCalls with Go Bindings:
-1. There is an example project for go in the `./examples/go/` directory, ensure you are in that directory
-2. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
+1. There is an example project for Go in `./examples/go/` directory, ensure you are in that directory
+2. Prerequisites for building are the same as for building library itself and can be found [here](https://pytgcalls.github.io/NTgCalls/Build%20Guide#Installing=Prerequisites)
+3. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
     1. Static won't work
-3. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
-4. The rest of the files should be copied to `./examples/go/` directory
+4. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
+5. The rest of the files should be copied to `./examples/go/` directory
     1. `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
-5. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
+6. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
     1. `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
     2. `CGO_ENABLED=1 go run .` for UNIX
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ NativeTgCalls offers Py Bindings, enabling seamless integration with Python. Fol
 NativeTgCalls offers Go Bindings, enabling seamless integration with Go. Follow these steps to compile NativeTgCalls with Go Bindings:
 1. There is an example project for go in the `./examples/go/` directory, ensure you are in that directory
 2. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
-  1. Static won't work
+    1. Static won't work
 3. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
 4. The rest of the files should be copied to `./examples/go/` directory
-  1. `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
+    1. `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
 5. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
-  1. `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
-  2. `CGO_ENABLED=1 go run .` for UNIX
+    1. `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
+    2. `CGO_ENABLED=1 go run .` for UNIX
 
 
 ### C Bindings

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ NativeTgCalls offers Py Bindings, enabling seamless integration with Python. Fol
 NativeTgCalls offers Go Bindings, enabling seamless integration with Go. Follow these steps to compile NativeTgCalls with Go Bindings:
 1. There is an example project for go in the `./examples/go/` directory, ensure you are in that directory
 2. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
-2.1 Static won't work
+  1. Static won't work
 3. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
 4. The rest of the files should be copied to `./examples/go/` directory
-4.1 `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
+  1. `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
 5. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
-5.1 `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
-5.2 `CGO_ENABLED=1 go run .` for UNIX
+  1. `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
+  2. `CGO_ENABLED=1 go run .` for UNIX
 
 
 ### C Bindings

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ NativeTgCalls offers Py Bindings, enabling seamless integration with Python. Fol
    ```shell
    python3 setup.py install
    ```
+### Go Bindings
+NativeTgCalls offers Go Bindings, enabling seamless integration with Go. Follow these steps to compile NativeTgCalls with Go Bindings:
+1. There is an example project for go in the `./examples/go/` directory, ensure you are in that directory
+2. Download **shared** release of the library from https://github.com/pytgcalls/ntgcalls/releases
+  2.1 Static won't work
+3. Copy `ntgcalls.h` file into `./examples/go/ntgcalls/` directory
+4. The rest of the files should be copied to `./examples/go/` directory
+  4.1 `ntgcalls.dll` and `ntgcalls.lib` files in case of Windows amd64 shared release
+5. Then in `./examples/go/` directory run `go build` or `go run .` with CGO_ENABLED=1 env variable set
+  5.1 `$env:CGO_ENABLED=1; go run .` for Windows PowerShell
+  5.2 `CGO_ENABLED=1 go run .` for UNIX
+
+
 ### C Bindings
 For developers looking to use NativeTgCalls with C and C++, we provide C Bindings. Follow these steps to compile NativeTgCalls with C Bindings:
 1. Ensure you are in the root directory of the NativeTgCalls project.


### PR DESCRIPTION
Readme section on how to compile/run provided example in `Go` lang

https://github.com/pytgcalls/ntgcalls/issues/24