### PR TITLE
Update due to error in the example code

### DIFF
--- a/examples/python/shell_reader.py
+++ b/examples/python/shell_reader.py
@@ -17,7 +17,7 @@ async def main():
     link = 'https://docs.evostream.com/sample_content/assets/sintel1m720p.mp4'
 
     async with client:
-        call_params = wrtc.create_call(
+        call_params = await wrtc.create_call(
             chat_id,
             MediaDescription(
                 audio=AudioDescription(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bbcc64bb-b0cd-4bdd-9d28-2d72a7fb8753)

As the docs say, `create_call` is an asynchronous method, and the example code does not use await in that `Future`