### PR TITLE
Fix MANIFEST to get proper WebRTC Version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include deps *
 recursive-include include *
 recursive-include ntgcalls *
 include CMakeLists.txt
+include version.properties


### PR DESCRIPTION
I've been trying to build ntgcalls on Windows with Python bindings. and errors would occur due to being unable to find the `version.properties` file to obtain the `version.webrtc`.

This PR fixes that issue and ensures that the `version.properties` file is properly brought into the PyPi build directory.

Command used: `python setup.py install`, tried `python -m build` as well.