### PR TITLE
fix: StreamManager::optimizeSources() checks the wrong maps for Microphone, so incoming audio is never enabled

### DIFF
--- a/ntgcalls/src/stream_manager.cpp
+++ b/ntgcalls/src/stream_manager.cpp
@@ -83,7 +83,18 @@ namespace ntgcalls {
     }
 
     void StreamManager::optimizeSources(wrtc::NetworkInterface* pc) {
-        pc->enableAudioIncoming(writers.contains(Microphone) || externalWriters.contains(Microphone));
+        // Microphone is a Capture-mode device: its state lives in
+        // readers/externalReaders (see handleCaptureConfig()), never in
+        // writers/externalWriters, which handlePlaybackConfig() populates
+        // for Playback-mode devices only. writers.contains(Microphone) can
+        // therefore never be true, so enableAudioIncoming(true) was never
+        // actually reachable - incoming audio channels never got created
+        // for any call that only sets up a capture (microphone) + playback
+        // (also Microphone, per P2PCall::connect()'s addTrack calls) audio
+        // pair, which is the normal case for external-audio-source P2P
+        // calls. Use the existing hasDeviceInternal() helper, which already
+        // encodes the correct per-mode map lookup.
+        pc->enableAudioIncoming(hasDeviceInternal(Capture, Microphone));
         pc->enableVideoIncoming(writers.contains(Camera) || externalWriters.contains(Camera), false);
         pc->enableVideoIncoming(writers.contains(Screen) || externalWriters.contains(Screen), true);
         initialized = pc->getConnectionMode() != wrtc::ConnectionMode::None;


### PR DESCRIPTION
## Bug

`StreamManager::optimizeSources()` decides whether to enable receiving the
remote peer's audio like this:

```cpp
void StreamManager::optimizeSources(wrtc::NetworkInterface* pc) {
    pc->enableAudioIncoming(writers.contains(Microphone) || externalWriters.contains(Microphone));
    ...
}
```

`writers` / `externalWriters` are populated exclusively by
`handlePlaybackConfig()` (i.e. only for **Playback**-mode devices).
`Microphone`, however, is always a **Capture**-mode device - its config is
tracked in `readers` / `externalReaders`, populated by
`handleCaptureConfig()`. So `writers.contains(Microphone)` (and the
`externalWriters` variant) can never be true for any real call, and
`enableAudioIncoming(true)` is effectively unreachable.

Concretely: `P2PCall::connect()` sets up the following tracks for every P2P
call:

```cpp
streamManager->addTrack(StreamManager::Mode::Capture, StreamManager::Device::Microphone, connection.get());
streamManager->addTrack(StreamManager::Mode::Capture, StreamManager::Device::Camera, connection.get());
streamManager->addTrack(StreamManager::Mode::Playback, StreamManager::Device::Microphone, connection.get());
streamManager->addTrack(StreamManager::Mode::Playback, StreamManager::Device::Camera, connection.get());
```

i.e. the remote peer's voice track is `{Playback, Microphone}` - never
`{Playback, Speaker}`. Since `optimizeSources()` only ever checks the
`writers`/`externalWriters` maps for `Microphone`, and those maps are never
populated for `Microphone` (only for genuinely Playback-mode devices),
`audioIncoming` stays `false` forever, and
`NativeNetworkInterface::addIncomingSmartSource()` never constructs an
`IncomingAudioChannel` for the remote audio - the RTP/SRTP layer works fine,
but no `RawAudioSink` ever gets attached, so `ntg_on_frames` (or the C++
`onFrames` callback) never fires, even though decrypted audio genuinely
arrives on the wire.

## Repro / how we found it

Hit this integrating ntgcalls into a C++ consumer via the flat C API, doing
a standard external-audio-source P2P call:

```c
ntg_media_description_struct capture_desc{};
capture_desc.microphone = &audio_desc;      // NTG_EXTERNAL
ntg_set_stream_sources(ptr, chatId, NTG_STREAM_CAPTURE, capture_desc, ...);

ntg_media_description_struct playback_desc{};
playback_desc.microphone = &audio_desc;     // NTG_EXTERNAL
ntg_set_stream_sources(ptr, chatId, NTG_STREAM_PLAYBACK, playback_desc, ...);

ntg_connect_p2p(ptr, chatId, ...);
```

Confirmed via a real Android<->P2P call and packet capture:

- DTLS handshake completes, SRTP activates correctly
  (`SRTP activated with negotiated parameters: ...`).
- `tcpdump` shows real, continuously arriving encrypted RTP from the peer.
- `ntg_on_frames` never fires, not even once, for the whole call.
- Adding a log line at the very top of `IncomingAudioChannel`'s constructor
  shows it is simply never called - confirming `addIncomingSmartSource()`
  never runs the `Audio` branch because `isAddable` (== `audioIncoming`) is
  always `false`.

## Fix

`hasDeviceInternal(Mode, Device)` already implements exactly the right
per-mode lookup:

```cpp
bool StreamManager::hasDeviceInternal(const Mode mode, const Device device) const {
    if (mode == Capture) {
        return readers.contains(device) || externalReaders.contains(device);
    }
    return writers.contains(device) || externalWriters.contains(device);
}
```

So the fix is a one-line change, reusing it:

```cpp
pc->enableAudioIncoming(hasDeviceInternal(Capture, Microphone));
```

(i.e. "do we have an active microphone/capture source", which is the
condition that actually correlates with whether this side is participating
in two-way audio - matching the existing intent, just fixed to query the
right maps.)

Branch: `fix/optimize-sources-audio-incoming-check` (1 commit) - happy to
open this as a PR against `master` if that's the right target branch, or
against `dev` if preferred.

## Note on video

The two lines right below (`enableVideoIncoming` for `Camera`/`Screen`) are
*not* affected by the same bug - unlike audio, `P2PCall::connect()`'s
`addTrack()` calls use `Camera` for **both** Capture and Playback video
(there's no separate "receive" device the way `Speaker` exists but is
unused for audio), so `writers`/`externalWriters` genuinely do get
populated for `Camera` in the Playback-mode case. Just flagging this so it
doesn't get bundled in by mistake - the audio case is the only broken one
here.