### PR TITLE
fix: add missing <cstring>/<utility> includes

### DIFF
--- a/wrtc/src/models/i420_image_data.cpp
+++ b/wrtc/src/models/i420_image_data.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <wrtc/models/i420_image_data.hpp>
+#include <cstring>
 
 namespace wrtc {
     size_t i420ImageData::sizeOfLuminancePlane() const {

--- a/wrtc/src/utils/bignum.cpp
+++ b/wrtc/src/utils/bignum.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <wrtc/utils/bignum.hpp>
+#include <utility>
 
 namespace openssl {
     void BigNum::clear() const {

--- a/wrtc/src/utils/encryption.cpp
+++ b/wrtc/src/utils/encryption.cpp
@@ -6,6 +6,7 @@
 
 #include <openssl/aes.h>
 #include <climits>
+#include <cstring>
 
 namespace openssl {
     bytes::vector Sha256::Digest(const bytes::const_span data) {


### PR DESCRIPTION
## Bug

`wrtc/src/models/i420_image_data.cpp`, `wrtc/src/utils/bignum.cpp` and
`wrtc/src/utils/encryption.cpp` use `memcpy`/`memset` (`<cstring>`) and
`std::move` (`<utility>`) without including either header directly. This
only compiled because libc++'s other, transitively-included headers
happened to pull them in.

Building against libstdc++ (i.e. a plain GCC/libstdc++ consumer with
`USE_LIBCXX=OFF`) surfaces these as real compile errors, since libstdc++'s
own headers don't transitively include the same things.

## Fix

Add the direct `#include <cstring>` / `#include <utility>` lines - correct
regardless of which standard library implementation is actually in use,
not just a `USE_LIBCXX=OFF` workaround.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/ntgcalls/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787216656&installation_model_id=422679&pr_number=54&repository=pytgcalls%2Fntgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fntgcalls%2Fpull%2F54&signature=b2f673dbc043dc5be23e9c75ebb616b8dca60e779c3d66c9afabbfdb40d8ca69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->