### PR TITLE
fix(core): audit, optimize thread pool, fix event loop resolution

### DIFF
--- a/ntgcalls/include/ntgcalls/utils/binding_utils.hpp
+++ b/ntgcalls/include/ntgcalls/utils/binding_utils.hpp
@@ -18,6 +18,9 @@ RTC_LOG(LS_VERBOSE) << funcName << ": " << "Worker started";
 RTC_LOG(LS_VERBOSE) << "Worker finished";\
 END_WORKER_NO_LOG
 
+#include <algorithm>
+#include <thread>
+
 #ifdef PYTHON_ENABLED
 #include <wrtc/utils/binary.hpp>
 #include <pybind11/pybind11.h>
@@ -69,8 +72,14 @@ py::object loop;\
 py::object executor;
 
 #define INIT_ASYNC \
-loop = py::module::import("asyncio").attr("get_event_loop")();\
-executor = py::module::import("concurrent.futures").attr("ThreadPoolExecutor")(std::min(static_cast<uint32_t>(32), std::thread::hardware_concurrency()));
+try {\
+    loop = py::module::import("asyncio").attr("get_running_loop")();\
+} catch (const py::error_already_set&) {\
+    loop = py::module::import("asyncio").attr("get_event_loop_policy")().attr("get_event_loop")();\
+}\
+const uint32_t concurrency = std::thread::hardware_concurrency();\
+const uint32_t workers = std::clamp(concurrency == 0 ? 4u : concurrency, 1u, 32u);\
+executor = py::module::import("concurrent.futures").attr("ThreadPoolExecutor")(workers);
 
 #define DESTROY_ASYNC \
 executor.attr("shutdown")(py::arg("wait") = true);\

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,12 @@ def install_cmake(cmake_version: str):
 with open(os.path.join(base_path, 'CMakeLists.txt'), 'r', encoding='utf-8') as f:
     if sys.platform.startswith('linux'):
         install_cmake(CMAKE_VERSION)
-    regex = re.compile(r'VERSION ([0-9.]+)', re.MULTILINE)
+    content = f.read()
+    project_version_match = re.search(r'project\s*\(\s*\w+\s+VERSION\s+([0-9.]+)', content)
+    project_ver = project_version_match.group(1) if project_version_match else '2.2.5'
     cmake_command = [
         str(cmake_bin()),
-        f'-DPROJECT_VERSION={re.findall(regex, f.read())[1]}',
+        f'-DPROJECT_VERSION={project_ver}',
         '-P',
         'cmake/VersionUtil.cmake',
     ]

--- a/tests/test_ntgcalls.py
+++ b/tests/test_ntgcalls.py
@@ -1,12 +1,33 @@
 import unittest
-from ntgcalls import NTgCalls
+from ntgcalls import NTgCalls, ConnectionNotFound
 
 
 class TestNTgCalls(unittest.IsolatedAsyncioTestCase):
     async def test_ping(self):
-        result = NTgCalls().ping()
+        result = NTgCalls.ping()
         self.assertEqual(result, "pong")
-        self.assertIsNotNone(result)
+
+    async def test_get_protocol(self):
+        protocol = NTgCalls.get_protocol()
+        self.assertIsNotNone(protocol)
+        self.assertTrue(hasattr(protocol, "min_layer"))
+        self.assertTrue(hasattr(protocol, "max_layer"))
+
+    async def test_get_media_devices(self):
+        devices = NTgCalls.get_media_devices()
+        self.assertIsNotNone(devices)
+
+    async def test_instance_methods(self):
+        client = NTgCalls()
+        usage = await client.cpu_usage()
+        self.assertIsInstance(usage, float)
+        active_calls = await client.calls()
+        self.assertIsInstance(active_calls, dict)
+
+    async def test_invalid_chat_exception(self):
+        client = NTgCalls()
+        with self.assertRaises(ConnectionNotFound):
+            await client.get_state(999999)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Guard ThreadPoolExecutor max_workers against zero hardware concurrency in binding_utils.hpp
- Upgrade Python asyncio event loop resolution for Python 3.10+ compatibility
- Make CMake project version parsing robust in setup.py
- Expand test_ntgcalls.py with static, async instance, and exception test cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/ntgcalls/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788088299&installation_model_id=422679&pr_number=56&repository=pytgcalls%2Fntgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fntgcalls%2Fpull%2F56&signature=f5d29ad519506635017d56c814c348c406484d786517f1a06eb256d229691f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->