### PR TITLE
fix: PlatformUtils.cmake uses CMAKE_CURRENT_LIST_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/cmake/PlatformUtils.cmake
+++ b/cmake/PlatformUtils.cmake
@@ -1,4 +1,4 @@
-set(cmake_dir ${CMAKE_SOURCE_DIR}/cmake)
+set(cmake_dir ${CMAKE_CURRENT_LIST_DIR})
 if(WIN32)
     set(OS_NAME WINDOWS)
 elseif (UNIX AND NOT APPLE)


### PR DESCRIPTION
Split out of #53 per @Laky-64's [review](https://github.com/pytgcalls/ntgcalls/pull/53#issuecomment-5164234629) - this is just point 2 from that PR, which stands on its own merits independent of the rest of the `add_subdirectory()` support work.

`CMAKE_SOURCE_DIR` resolves to the top-level source directory of whatever project includes this file, not necessarily ntgcalls' own root - this only happens to work today because every current build path processes `PlatformUtils.cmake` from ntgcalls' own top-level `CMakeLists.txt`. `CMAKE_CURRENT_LIST_DIR` is the correct choice here: it always resolves to this file's own directory (`cmake/`), regardless of who includes it or from where.

The remaining `add_subdirectory()` points from #53 (covering `VersionUtil.cmake`/`GenerateE2ETL.cmake`, plus include guards for `PlatformUtils.cmake`/`DownloadProject.cmake`/`GitUtils.cmake`) will follow separately once that's fleshed out further, per the review feedback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pytgcalls/codesmith/ntgcalls/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788977477&installation_model_id=422679&pr_number=57&repository=pytgcalls%2Fntgcalls&return_to=https%3A%2F%2Fgithub.com%2Fpytgcalls%2Fntgcalls%2Fpull%2F57&signature=c5a19a4a57ebc896cb799f58cf594722a6609cf8a5fe4d23639db9164b8565e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->